### PR TITLE
feat: add create ns tool

### DIFF
--- a/pkg/karmada/cluster.go
+++ b/pkg/karmada/cluster.go
@@ -13,7 +13,7 @@ import (
 func ListClusters(getClient GetClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool(
 			"list_clusters",
-			mcp.WithDescription("List all clusters in the Karmada control plane."),
+			mcp.WithDescription("List all clusters in the Karmada control-plane."),
 		),
 
 		func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/pkg/karmada/namespace.go
+++ b/pkg/karmada/namespace.go
@@ -1,0 +1,43 @@
+package karmada
+
+import (
+	"context"
+	"fmt"
+	ns "github.com/karmada-io/dashboard/pkg/resource/namespace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func CreateNamespace(getKubernetesClient GetKubernetesClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"create_namespace",
+			mcp.WithDescription("Create a namespace resources in the Karmada control-plane"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("name for the namespace")),
+			mcp.WithBoolean("skipAutoPropagation", mcp.Required(), mcp.Description("whether propagation the namespace automatically")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKubernetesClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %w", err)
+			}
+
+			paramName, ok := request.Params.Arguments["name"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter name not found")
+			}
+
+			paramSkipAutoPropagation, ok := request.Params.Arguments["skipAutoPropagation"].(bool)
+			if !ok {
+				return nil, fmt.Errorf("parameter name not found")
+			}
+			spec := &ns.NamespaceSpec{
+				Name:                paramName,
+				SkipAutoPropagation: paramSkipAutoPropagation,
+			}
+			if err = ns.CreateNamespace(spec, karmadaClient); err != nil {
+				return nil, fmt.Errorf("failed to create namespace: %w", err)
+			}
+
+			return mcp.NewToolResultText("create namespace success"), nil
+		}
+}

--- a/pkg/karmada/propagationpolicy.go
+++ b/pkg/karmada/propagationpolicy.go
@@ -1,0 +1,1 @@
+package karmada

--- a/pkg/karmada/tools.go
+++ b/pkg/karmada/tools.go
@@ -3,9 +3,11 @@ package karmada
 import (
 	"context"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"k8s.io/client-go/kubernetes"
 )
 
 type GetClientFn func(context.Context) (karmadaclientset.Interface, error)
+type GetKubernetesClientFn func(context.Context) (kubernetes.Interface, error)
 
 func InitToolsets(passedToolsets []string, getClient GetClientFn) error {
 	return nil


### PR DESCRIPTION
## Summary by Sourcery

Add a new tool for creating namespaces in the Karmada control-plane

New Features:
- Implement a new tool to create namespaces with optional auto-propagation setting

Enhancements:
- Extend the MCP server to support namespace creation functionality