### PR TITLE
feat: add sse mode

### DIFF
--- a/cmd/karmada-mcp-server/main.go
+++ b/cmd/karmada-mcp-server/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/karmada-io/dashboard/pkg/client"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -37,6 +38,16 @@ var (
 			}
 		},
 	}
+	sseCmd = &cobra.Command{
+		Use:   "sse",
+		Short: "Start sse server",
+		Long:  `Start a server that communicates via standard input/output streams using JSON-RPC messages.`,
+		Run: func(_ *cobra.Command, _ []string) {
+			if err := runSseServer(); err != nil {
+
+			}
+		},
+	}
 )
 
 func init() {
@@ -55,6 +66,7 @@ func init() {
 
 	// Add subcommands
 	rootCmd.AddCommand(stdioCmd)
+	rootCmd.AddCommand(sseCmd)
 }
 
 func initConfig() {
@@ -123,6 +135,105 @@ func runStdioServer() error {
 			return fmt.Errorf("error running server: %w", err)
 		}
 	}
+
+	return nil
+}
+
+func runSseServer() error {
+	// Create app context
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx = ctx
+	hooks := &server.Hooks{}
+
+	hooks.AddBeforeAny(func(ctx context.Context, id any, method mcp.MCPMethod, message any) {
+		fmt.Printf("beforeAny: %s, %v, %v\n", method, id, message)
+	})
+	hooks.AddOnSuccess(func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
+		fmt.Printf("onSuccess: %s, %v, %v, %v\n", method, id, message, result)
+	})
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		fmt.Printf("onError: %s, %v, %v, %v\n", method, id, message, err)
+	})
+	hooks.AddBeforeInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest) {
+		fmt.Printf("beforeInitialize: %v, %v\n", id, message)
+	})
+	hooks.AddOnRequestInitialization(func(ctx context.Context, id any, message any) error {
+		fmt.Printf("AddOnRequestInitialization: %v, %v\n", id, message)
+		// authorization verification and other preprocessing tasks are performed.
+		return nil
+	})
+	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+		fmt.Printf("afterInitialize: %v, %v, %v\n", id, message, result)
+	})
+	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
+		fmt.Printf("afterCallTool: %v, %v, %v\n", id, message, result)
+	})
+	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
+		fmt.Printf("beforeCallTool: %v, %v\n", id, message)
+	})
+
+	// Create a new MCP server
+	karmadaServer := karmada.NewServer(version,
+		server.WithHooks(hooks),
+		server.WithLogging(),
+	)
+
+	// init client for karmada apiserver
+	client.InitKarmadaConfig(
+		client.WithKubeconfig(viper.GetString("karmada-kubeconfig")),
+		client.WithKubeContext(viper.GetString("karmada-context")),
+		client.WithInsecureTLSSkipVerify(viper.GetBool("skip-karmada-apiserver-tls-verify")),
+	)
+
+	karmadaClient := client.InClusterKarmadaClient()
+	getClient := func(_ context.Context) (karmadaclientset.Interface, error) {
+		return karmadaClient, nil // closing over client
+	}
+
+	k8sClient := client.InClusterClientForKarmadaAPIServer()
+
+	getKubernetesClient := func(_ context.Context) (kubernetes.Interface, error) {
+		return k8sClient, nil // closing over client
+	}
+
+	{
+		tool, handler := karmada.ListClusters(getClient)
+		karmadaServer.AddTool(tool, handler)
+	}
+
+	{
+		tool, handler := karmada.CreateNamespace(getKubernetesClient)
+		karmadaServer.AddTool(tool, handler)
+	}
+
+	sseServer := server.NewSSEServer(karmadaServer,
+		server.WithBaseURL("http://localhost:5173"),
+		server.WithStaticBasePath("/mcp"),
+	)
+	sseServer.Start("localhost:1234")
+	//
+	/*
+		// Start listening for messages
+		errC := make(chan error, 1)
+		go func() {
+			//in, out := io.Reader(os.Stdin), io.Writer(os.Stdout)
+			// errC <- sseServer.Listen(ctx, in, out)
+			sseServer.Start("localhost:7890")
+		}()
+
+		// Output karmada-mcp-server string
+		_, _ = fmt.Fprintf(os.Stderr, "Karmada MCP Server running on stdio\n")
+
+		// Wait for shutdown signal
+		select {
+		case <-ctx.Done():
+			fmt.Errorf("shutting down server...")
+		case err := <-errC:
+			if err != nil {
+				return fmt.Errorf("error running server: %w", err)
+			}
+		}*/
 
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/karmada-io/dashboard v0.1.0
 	github.com/karmada-io/karmada v1.12.1
-	github.com/mark3labs/mcp-go v0.22.0
+	github.com/mark3labs/mcp-go v0.26.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2
 )

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mark3labs/mcp-go v0.22.0 h1:cCEBWi4Yy9Kio+OW1hWIyi4WLsSr+RBBK6FI5tj+b7I=
 github.com/mark3labs/mcp-go v0.22.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
+github.com/mark3labs/mcp-go v0.26.0 h1:xz/Kv1cHLYovF8txv6btBM39/88q3YOjnxqhi51jB0w=
+github.com/mark3labs/mcp-go v0.26.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new SSE server mode to the CLI, enabling server communication via Server-Sent Events, and update the mcp-go dependency.

New Features:
- Add SSE server mode as a new command to the server CLI.

Enhancements:
- Upgrade mcp-go dependency to v0.26.0.