### PR TITLE
Feat/modular

### DIFF
--- a/cmd/karmada-mcp-server/app/sse.go
+++ b/cmd/karmada-mcp-server/app/sse.go
@@ -1,0 +1,125 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"github.com/karmada-io/dashboard/pkg/client"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+	"github.com/warjiang/karmada-mcp-server/pkg/karmada"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func NewSseCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sse",
+		Short: "Start sse server",
+		Long:  `Start a server that communicates via standard input/output streams using JSON-RPC messages.`,
+		Run: func(_ *cobra.Command, _ []string) {
+			if err := runSseServer(); err != nil {
+
+			}
+		},
+	}
+
+	return cmd
+}
+
+func runSseServer() error {
+	klog.Infof("Starting sse server")
+	// Create app context
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx = ctx
+	hooks := &server.Hooks{}
+
+	hooks.AddBeforeAny(func(ctx context.Context, id any, method mcp.MCPMethod, message any) {
+		fmt.Printf("beforeAny: %s, %v, %v\n", method, id, message)
+	})
+	hooks.AddOnSuccess(func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
+		fmt.Printf("onSuccess: %s, %v, %v, %v\n", method, id, message, result)
+	})
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		fmt.Printf("onError: %s, %v, %v, %v\n", method, id, message, err)
+	})
+	hooks.AddBeforeInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest) {
+		fmt.Printf("beforeInitialize: %v, %v\n", id, message)
+	})
+	hooks.AddOnRequestInitialization(func(ctx context.Context, id any, message any) error {
+		fmt.Printf("AddOnRequestInitialization: %v, %v\n", id, message)
+		// authorization verification and other preprocessing tasks are performed.
+		return nil
+	})
+	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+		fmt.Printf("afterInitialize: %v, %v, %v\n", id, message, result)
+	})
+	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
+		fmt.Printf("afterCallTool: %v, %v, %v\n", id, message, result)
+	})
+	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
+		fmt.Printf("beforeCallTool: %v, %v\n", id, message)
+	})
+
+	// Create a new MCP server
+	karmadaServer := karmada.NewServer("version",
+		server.WithHooks(hooks),
+		server.WithLogging(),
+	)
+
+	karmadaClient := client.InClusterKarmadaClient()
+	getClient := func(_ context.Context) (karmadaclientset.Interface, error) {
+		return karmadaClient, nil // closing over client
+	}
+
+	k8sClient := client.InClusterClientForKarmadaAPIServer()
+
+	getKubernetesClient := func(_ context.Context) (kubernetes.Interface, error) {
+		return k8sClient, nil // closing over client
+	}
+
+	{
+		tool, handler := karmada.ListClusters(getClient)
+		karmadaServer.AddTool(tool, handler)
+	}
+
+	{
+		tool, handler := karmada.CreateNamespace(getKubernetesClient)
+		karmadaServer.AddTool(tool, handler)
+	}
+
+	sseServer := server.NewSSEServer(karmadaServer,
+		server.WithBaseURL("http://localhost:5173"),
+		server.WithStaticBasePath("/mcp"),
+	)
+	sseServer.Start("localhost:1234")
+	//
+	/*
+		// Start listening for messages
+		errC := make(chan error, 1)
+		go func() {
+			//in, out := io.Reader(os.Stdin), io.Writer(os.Stdout)
+			// errC <- sseServer.Listen(ctx, in, out)
+			sseServer.Start("localhost:7890")
+		}()
+
+		// Output karmada-mcp-server string
+		_, _ = fmt.Fprintf(os.Stderr, "Karmada MCP Server running on stdio\n")
+
+		// Wait for shutdown signal
+		select {
+		case <-ctx.Done():
+			fmt.Errorf("shutting down server...")
+		case err := <-errC:
+			if err != nil {
+				return fmt.Errorf("error running server: %w", err)
+			}
+		}*/
+
+	return nil
+}

--- a/cmd/karmada-mcp-server/app/stdio.go
+++ b/cmd/karmada-mcp-server/app/stdio.go
@@ -1,0 +1,89 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"github.com/karmada-io/dashboard/pkg/client"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/spf13/cobra"
+	"github.com/warjiang/karmada-mcp-server/pkg/karmada"
+	"io"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func NewStdioCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stdio",
+		Short: "Start stdio server",
+		Long:  `Start a server that communicates via standard input/output streams using JSON-RPC messages.`,
+		Run: func(_ *cobra.Command, _ []string) {
+			if err := runStdioServer(); err != nil {
+
+			}
+		},
+	}
+	return cmd
+}
+
+func runStdioServer() error {
+	klog.Info("Starting mcp server in stdio mode")
+	// 4 3 2 1
+	// Create app context
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	hooks := &server.Hooks{}
+
+	// Create a new MCP server
+	karmadaServer := karmada.NewServer("version", server.WithHooks(hooks))
+
+	karmadaClient := client.InClusterKarmadaClient()
+	getClient := func(_ context.Context) (karmadaclientset.Interface, error) {
+		return karmadaClient, nil // closing over client
+	}
+
+	k8sClient := client.InClusterClientForKarmadaAPIServer()
+	getKubernetesClient := func(_ context.Context) (kubernetes.Interface, error) {
+		return k8sClient, nil // closing over client
+	}
+
+	{
+		tool, handler := karmada.ListClusters(getClient)
+		karmadaServer.AddTool(tool, handler)
+	}
+
+	{
+		tool, handler := karmada.CreateNamespace(getKubernetesClient)
+		karmadaServer.AddTool(tool, handler)
+	}
+
+	stdioServer := server.NewStdioServer(karmadaServer)
+
+	// Start listening for messages
+	errC := make(chan error, 1)
+	go func() {
+		in, out := io.Reader(os.Stdin), io.Writer(os.Stdout)
+
+		errC <- stdioServer.Listen(ctx, in, out)
+	}()
+
+	// Output karmada-mcp-server string
+	_, _ = fmt.Fprintf(os.Stderr, "Karmada MCP Server running on stdio\n")
+
+	// Wait for shutdown signal
+	select {
+	case <-ctx.Done():
+		fmt.Errorf("shutting down server...")
+	case err := <-errC:
+		if err != nil {
+			return fmt.Errorf("error running server: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/mark3labs/mcp-go v0.26.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.18.2
+	k8s.io/client-go v0.31.2
+	k8s.io/component-base v0.31.2
 )
 
 require (
@@ -65,7 +67,6 @@ require (
 	k8s.io/api v0.31.2 // indirect
 	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/apimachinery v0.31.2 // indirect
-	k8s.io/client-go v0.31.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0V
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
-github.com/mark3labs/mcp-go v0.22.0 h1:cCEBWi4Yy9Kio+OW1hWIyi4WLsSr+RBBK6FI5tj+b7I=
-github.com/mark3labs/mcp-go v0.22.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mark3labs/mcp-go v0.26.0 h1:xz/Kv1cHLYovF8txv6btBM39/88q3YOjnxqhi51jB0w=
 github.com/mark3labs/mcp-go v0.26.0/go.mod h1:rXqOudj/djTORU/ThxYx8fqEVj/5pvTuuebQ2RC7uk4=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
@@ -192,6 +190,8 @@ k8s.io/apimachinery v0.31.2 h1:i4vUt2hPK56W6mlT7Ry+AO8eEsyxMD1U44NR22CLTYw=
 k8s.io/apimachinery v0.31.2/go.mod h1:rsPdaZJfTfLsNJSQzNHQvYoTmxhoOEofxtOsF3rtsMo=
 k8s.io/client-go v0.31.2 h1:Y2F4dxU5d3AQj+ybwSMqQnpZH9F30//1ObxOKlTI9yc=
 k8s.io/client-go v0.31.2/go.mod h1:NPa74jSVR/+eez2dFsEIHNa+3o09vtNaWwWwb1qSxSs=
+k8s.io/component-base v0.31.2 h1:Z1J1LIaC0AV+nzcPRFqfK09af6bZ4D1nAOpWsy9owlA=
+k8s.io/component-base v0.31.2/go.mod h1:9PeyyFN/drHjtJZMCTkSpQJS3U9OXORnHQqMLDz0sUQ=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
 k8s.io/kube-openapi v0.0.0-20240430033511-f0e62f92d13f h1:0LQagt0gDpKqvIkAMPaRGcXawNMouPECM1+F9BVxEaM=

--- a/pkg/karmada/server.go
+++ b/pkg/karmada/server.go
@@ -11,6 +11,7 @@ func NewServer(version string, opts ...server.ServerOption) *server.MCPServer {
 		server.WithLogging(),
 	}
 	opts = append(defaultOpts, opts...)
+
 	// Create a new MCP server
 	s := server.NewMCPServer(
 		"karmada-mcp-server",

--- a/pkg/karmada/tools.go
+++ b/pkg/karmada/tools.go
@@ -3,12 +3,36 @@ package karmada
 import (
 	"context"
 	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	toolsets "github.com/warjiang/karmada-mcp-server/pkg/toolset"
 	"k8s.io/client-go/kubernetes"
 )
 
 type GetClientFn func(context.Context) (karmadaclientset.Interface, error)
+
 type GetKubernetesClientFn func(context.Context) (kubernetes.Interface, error)
 
-func InitToolsets(passedToolsets []string, getClient GetClientFn) error {
-	return nil
+var DefaultTools = []string{"all"}
+
+func InitToolsetGroup(passedToolsets []string, readOnly bool, getClient GetClientFn) (*toolsets.ToolsetGroup, error) {
+	// Create a new toolset group
+	tsg := toolsets.NewToolsetGroup(readOnly)
+
+	// Define all available features with their default state (disabled)
+	// Create toolsets
+	clusters := toolsets.NewToolset("cluster", "Karmada cluster related tools").
+		AddReadTools().
+		AddWriteTools()
+	policies := toolsets.NewToolset("policy", "Karmada policy related tools").
+		AddReadTools().
+		AddWriteTools()
+	// Add toolsets to the group
+	tsg.AddToolset(clusters)
+	tsg.AddToolset(policies)
+
+	// Enable the requested features
+	if err := tsg.EnableToolsets(passedToolsets); err != nil {
+		return nil, err
+	}
+
+	return tsg, nil
 }


### PR DESCRIPTION
## Summary by Sourcery

Set up a modular toolset abstraction for Karmada tools, integrate client and logging flag initialization into the CLI, and add two new server modes (stdio and SSE) for MCP communication.

New Features:
- Introduce InitToolsetGroup to compose and enable cluster and policy toolset groups.
- Add a "stdio" subcommand to launch the MCP server over standard input/output using JSON-RPC.
- Add an "sse" subcommand to launch the MCP server over Server-Sent Events with customizable hooks.

Enhancements:
- Initialize Karmada client configuration during command initialization and register klog logging flags under a dedicated flag set.
- Refactor main command to use constructor functions for subcommands instead of static variables.

Build:
- Add explicit dependencies on k8s.io/client-go and k8s.io/component-base in go.mod.