### PR TITLE
Feat/stdio mode

### DIFF
--- a/cmd/karmada-mcp-server/app/stdio.go
+++ b/cmd/karmada-mcp-server/app/stdio.go
@@ -3,63 +3,68 @@ package app
 import (
 	"context"
 	"fmt"
-	"github.com/karmada-io/dashboard/pkg/client"
-	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/warjiang/karmada-mcp-server/pkg/environment"
 	"github.com/warjiang/karmada-mcp-server/pkg/karmada"
 	"io"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
 	"os"
 	"os/signal"
 	"syscall"
 )
 
+type StdioServerConfig struct {
+	// Version of the server
+	Version string
+
+	// EnabledToolsets is a list of toolsets to enable
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#tool-configuration
+	EnabledToolsets []string
+	// ReadOnly indicates if we should only register read-only tools
+	ReadOnly bool
+}
+
 func NewStdioCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stdio",
 		Short: "Start stdio server",
 		Long:  `Start a server that communicates via standard input/output streams using JSON-RPC messages.`,
-		Run: func(_ *cobra.Command, _ []string) {
-			if err := runStdioServer(); err != nil {
-
+		RunE: func(_ *cobra.Command, _ []string) error {
+			// If you're wondering why we're not using viper.GetStringSlice("toolsets"),
+			// it's because viper doesn't handle comma-separated values correctly for env
+			// vars when using GetStringSlice.
+			// https://github.com/spf13/viper/issues/380
+			var enabledToolsets []string
+			if err := viper.UnmarshalKey("toolsets", &enabledToolsets); err != nil {
+				return fmt.Errorf("failed to unmarshal toolsets: %w", err)
 			}
+			stdioServerConfig := StdioServerConfig{
+				Version:         environment.Version(),
+				EnabledToolsets: enabledToolsets,
+				ReadOnly:        viper.GetBool("read-only"),
+			}
+			return runStdioServer(stdioServerConfig)
 		},
 	}
 	return cmd
 }
 
-func runStdioServer() error {
+func runStdioServer(cfg StdioServerConfig) error {
 	klog.Info("Starting mcp server in stdio mode")
-	// 4 3 2 1
+
 	// Create app context
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	hooks := &server.Hooks{}
-
-	// Create a new MCP server
-	karmadaServer := karmada.NewServer("version", server.WithHooks(hooks))
-
-	karmadaClient := client.InClusterKarmadaClient()
-	getClient := func(_ context.Context) (karmadaclientset.Interface, error) {
-		return karmadaClient, nil // closing over client
-	}
-
-	k8sClient := client.InClusterClientForKarmadaAPIServer()
-	getKubernetesClient := func(_ context.Context) (kubernetes.Interface, error) {
-		return k8sClient, nil // closing over client
-	}
-
-	{
-		tool, handler := karmada.ListClusters(getClient)
-		karmadaServer.AddTool(tool, handler)
-	}
-
-	{
-		tool, handler := karmada.CreateNamespace(getKubernetesClient)
-		karmadaServer.AddTool(tool, handler)
+	karmadaServer, err := karmada.NewMCPServer(karmada.MCPServerConfig{
+		Version:         cfg.Version,
+		EnabledToolsets: cfg.EnabledToolsets,
+		ReadOnly:        cfg.ReadOnly,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create MCP server: %w", err)
 	}
 
 	stdioServer := server.NewStdioServer(karmadaServer)
@@ -73,12 +78,12 @@ func runStdioServer() error {
 	}()
 
 	// Output karmada-mcp-server string
-	_, _ = fmt.Fprintf(os.Stderr, "Karmada MCP Server running on stdio\n")
+	klog.Info("Karmada MCP Server running on stdio\n")
 
 	// Wait for shutdown signal
 	select {
 	case <-ctx.Done():
-		fmt.Errorf("shutting down server...")
+		klog.Info("shutting down server...")
 	case err := <-errC:
 		if err != nil {
 			return fmt.Errorf("error running server: %w", err)

--- a/cmd/karmada-mcp-server/main.go
+++ b/cmd/karmada-mcp-server/main.go
@@ -63,7 +63,7 @@ func initKarmada() {
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		_, _ = fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/karmada/cluster.go
+++ b/pkg/karmada/cluster.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-func ListClusters(getClient GetClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+func ListClusters(getClient GetKarmadaClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
 	return mcp.NewTool(
 			"list_clusters",
 			mcp.WithDescription("List all clusters in the Karmada control-plane."),

--- a/pkg/karmada/config.go
+++ b/pkg/karmada/config.go
@@ -1,0 +1,13 @@
+package karmada
+
+type MCPServerConfig struct {
+	// Version of the server
+	Version string
+
+	// EnabledToolsets is a list of toolsets to enable
+	// See: https://github.com/github/github-mcp-server?tab=readme-ov-file#tool-configuration
+	EnabledToolsets []string
+
+	// ReadOnly indicates if we should only offer read-only tools
+	ReadOnly bool
+}

--- a/pkg/karmada/server.go
+++ b/pkg/karmada/server.go
@@ -1,6 +1,13 @@
 package karmada
 
-import "github.com/mark3labs/mcp-go/server"
+import (
+	"context"
+	"fmt"
+	"github.com/karmada-io/dashboard/pkg/client"
+	karmadaclientset "github.com/karmada-io/karmada/pkg/generated/clientset/versioned"
+	"github.com/mark3labs/mcp-go/server"
+	"k8s.io/client-go/kubernetes"
+)
 
 // NewServer creates a new GitHub MCP server with the specified GH client and logger.
 func NewServer(version string, opts ...server.ServerOption) *server.MCPServer {
@@ -19,4 +26,68 @@ func NewServer(version string, opts ...server.ServerOption) *server.MCPServer {
 		opts...,
 	)
 	return s
+}
+
+func NewMCPServer(cfg MCPServerConfig) (*server.MCPServer, error) {
+	// init karmada client
+	// init kubernetes client
+
+	hooks := &server.Hooks{}
+	/*
+		hooks.AddBeforeAny(func(ctx context.Context, id any, method mcp.MCPMethod, message any) {
+			fmt.Printf("beforeAny: %s, %v, %v\n", method, id, message)
+		})
+		hooks.AddOnSuccess(func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
+			fmt.Printf("onSuccess: %s, %v, %v, %v\n", method, id, message, result)
+		})
+		hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+			fmt.Printf("onError: %s, %v, %v, %v\n", method, id, message, err)
+		})
+		hooks.AddBeforeInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest) {
+			fmt.Printf("beforeInitialize: %v, %v\n", id, message)
+		})
+		hooks.AddOnRequestInitialization(func(ctx context.Context, id any, message any) error {
+			fmt.Printf("AddOnRequestInitialization: %v, %v\n", id, message)
+			// authorization verification and other preprocessing tasks are performed.
+			return nil
+		})
+		hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+			fmt.Printf("afterInitialize: %v, %v, %v\n", id, message, result)
+		})
+		hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
+			fmt.Printf("afterCallTool: %v, %v, %v\n", id, message, result)
+		})
+		hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
+			fmt.Printf("beforeCallTool: %v, %v\n", id, message)
+		})
+	*/
+
+	// Create karmada MCP server
+	karmadaServer := NewServer(cfg.Version, server.WithHooks(hooks))
+
+	karmadaClient := client.InClusterKarmadaClient()
+	getKarmadaClient := func(_ context.Context) (karmadaclientset.Interface, error) {
+		return karmadaClient, nil // closing over client
+	}
+
+	k8sClient := client.InClusterClientForKarmadaAPIServer()
+	getKubernetesClient := func(_ context.Context) (kubernetes.Interface, error) {
+		return k8sClient, nil // closing over client
+	}
+
+	enabledToolsets := cfg.EnabledToolsets
+	// Create default toolsets
+	toolsets, err := InitToolsetGroup(
+		enabledToolsets,
+		cfg.ReadOnly,
+		getKarmadaClient, getKubernetesClient,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize toolsets: %w", err)
+	}
+
+	// Register the tools with the server
+	toolsets.RegisterTools(karmadaServer)
+
+	return karmadaServer, nil
 }

--- a/pkg/toolset/helper.go
+++ b/pkg/toolset/helper.go
@@ -1,0 +1,10 @@
+package toolsets
+
+import (
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func NewServerTool(tool mcp.Tool, handler server.ToolHandlerFunc) server.ServerTool {
+	return server.ServerTool{Tool: tool, Handler: handler}
+}


### PR DESCRIPTION
## Summary by Sourcery

Implement stdio mode for the Karmada MCP server, enabling JSON-RPC communication over standard input/output with configurable toolsets and read-only mode. Introduce a new server constructor to bootstrap in-cluster Karmada and Kubernetes clients and dynamically register tools via a toolset group, and refactor tool initialization and logging.

New Features:
- Add StdioServerConfig and cobra subcommand for stdio mode with viper-driven toolset and read-only configuration
- Introduce NewMCPServer to initialize the MCP server with in-cluster Karmada and Kubernetes clients and configurable toolsets

Enhancements:
- Refactor InitToolsetGroup to accept separate Karmada and Kubernetes client functions and register tools via NewServerTool helper
- Replace inline tool registration and fmt logging in stdio mode with centralized hooks, klog logging, and stderr error output