### PR TITLE
Feat/pp

### DIFF
--- a/pkg/karmada/deployment.go
+++ b/pkg/karmada/deployment.go
@@ -22,7 +22,7 @@ func CreateDeployment(getKubernetesClient GetKubernetesClientFn) (tool mcp.Tool,
 			mcp.WithString("name", mcp.Required(), mcp.Description("name for deployment")),
 			mcp.WithString("namespace", mcp.Required(), mcp.Description("namespace for deployment")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("deployment content which in form of yaml")),
-			mcp.WithBoolean("dry-run", mcp.DefaultBool(true), mcp.Description("dry-run options, if true the resource will not be applied to apiserver directly")),
+			//mcp.WithBoolean("dry-run", mcp.DefaultBool(true), mcp.Description("dry-run options, if true the resource will not be applied to apiserver directly")),
 		),
 		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			karmadaClient, err := getKubernetesClient(ctx)

--- a/pkg/karmada/deployment.go
+++ b/pkg/karmada/deployment.go
@@ -1,0 +1,104 @@
+package karmada
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/karmada-io/dashboard/pkg/dataselect"
+	"github.com/karmada-io/dashboard/pkg/resource/common"
+	"github.com/karmada-io/dashboard/pkg/resource/deployment"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+func CreateDeployment(getKubernetesClient GetKubernetesClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"create_deployment",
+			mcp.WithDescription("Create a deployment resources in the Karmada control-plane"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("name for deployment")),
+			mcp.WithString("namespace", mcp.Required(), mcp.Description("namespace for deployment")),
+			mcp.WithString("content", mcp.Required(), mcp.Description("deployment content which in form of yaml")),
+			mcp.WithBoolean("dry-run", mcp.DefaultBool(true), mcp.Description("dry-run options, if true the resource will not be applied to apiserver directly")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKubernetesClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %w", err)
+			}
+
+			paramName, ok := request.Params.Arguments["name"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter name not found")
+			}
+
+			paramNamespace, ok := request.Params.Arguments["namespace"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter namespace not found")
+			}
+
+			paramContent, ok := request.Params.Arguments["content"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter content not found")
+			}
+			deployment := appsv1.Deployment{}
+			if err = yaml.Unmarshal([]byte(paramContent), &deployment); err != nil {
+				klog.Errorf("unmarshal deployment error: %v", err)
+				return nil, err
+			}
+			deployment.Name = paramName
+
+			createResp, err := karmadaClient.AppsV1().Deployments(paramNamespace).Create(ctx, &deployment, metav1.CreateOptions{})
+			if err != nil {
+				klog.Errorf("create deployment error: %v", err)
+				return nil, err
+			}
+
+			respBuff, err := json.Marshal(createResp)
+			if err != nil {
+				klog.Errorf("marshal created deployment error: %v", err)
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(respBuff)), nil
+		}
+}
+
+func ListDeployment(getKubernetesClient GetKubernetesClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"list_deployment",
+			mcp.WithDescription("List deployments under the specific namespace in the Karmada control-plane"),
+			mcp.WithString("namespace", mcp.Required(), mcp.Description("name of namespace")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKubernetesClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %w", err)
+			}
+
+			paramNamespace, ok := request.Params.Arguments["namespace"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter namespace not found")
+			}
+			namespace := common.NewNamespaceQuery([]string{paramNamespace})
+			resp, err := deployment.GetDeploymentList(karmadaClient, namespace, dataselect.NoDataSelect)
+			if err != nil {
+				klog.Errorf("failed to list deployments, err: %v", err)
+				return nil, err
+			}
+			deployList := make([]string, 0)
+			for _, deployment := range resp.Deployments {
+				deployList = append(deployList, deployment.ObjectMeta.Name)
+			}
+			r, err := json.Marshal(map[string]interface{}{
+				"deployments": deployList,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal deployments: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}

--- a/pkg/karmada/propagationpolicy.go
+++ b/pkg/karmada/propagationpolicy.go
@@ -1,1 +1,210 @@
 package karmada
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/karmada-io/dashboard/pkg/dataselect"
+	"github.com/karmada-io/dashboard/pkg/resource/common"
+	"github.com/karmada-io/dashboard/pkg/resource/propagationpolicy"
+	"github.com/karmada-io/karmada/pkg/apis/policy/v1alpha1"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+)
+
+func CreatePropagationPolicy(getKarmadaClient GetKarmadaClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"create_propagationpolicy",
+			mcp.WithDescription("Create a propagationpolicy resources in the Karmada control-plane"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("name for propagationpolicy")),
+			mcp.WithString("namespace", mcp.Required(), mcp.Description("namespace for propagationpolicy")),
+			mcp.WithString("content", mcp.Required(), mcp.Description(`propagationpolicy content which in form of yaml, one propagationpolicy yaml file likes:
+apiVersion: policy.karmada.io/v1alpha1
+kind: PropagationPolicy
+metadata:
+  name: nginx-propagation
+spec:
+  resourceSelectors:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: nginx
+  placement:
+    clusterAffinity:
+      clusterNames:
+        - member1
+        - member2
+    replicaScheduling:
+      replicaDivisionPreference: Weighted
+      replicaSchedulingType: Divided
+      weightPreference:
+        staticWeightList:
+          - targetCluster:
+              clusterNames:
+                - member1
+            weight: 1
+          - targetCluster:
+              clusterNames:
+                - member2
+            weight: 1
+`)),
+			//mcp.WithBoolean("dry-run", mcp.DefaultBool(true), mcp.Description("dry-run options, if true the resource will not be applied to apiserver directly")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKarmadaClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %w", err)
+			}
+
+			paramName, ok := request.Params.Arguments["name"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter name not found")
+			}
+
+			paramNamespace, ok := request.Params.Arguments["namespace"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter namespace not found")
+			}
+
+			paramContent, ok := request.Params.Arguments["content"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter content not found")
+			}
+			propagationPolicy := v1alpha1.PropagationPolicy{}
+			if err = yaml.Unmarshal([]byte(paramContent), &propagationPolicy); err != nil {
+				klog.Errorf("unmarshal propagationpolicy error: %v", err)
+				return nil, err
+			}
+			propagationPolicy.Name = paramName
+
+			createResp, err := karmadaClient.PolicyV1alpha1().PropagationPolicies(paramNamespace).Create(ctx, &propagationPolicy, metav1.CreateOptions{})
+			if err != nil {
+				klog.Errorf("create propagationpolicy error: %v", err)
+				return nil, err
+			}
+
+			respBuff, err := json.Marshal(createResp)
+			if err != nil {
+				klog.Errorf("marshal created propagationpolicy error: %v", err)
+				return nil, err
+			}
+			return mcp.NewToolResultText(string(respBuff)), nil
+		}
+}
+
+func ListPropagationPolicy(getKarmadaClient GetKarmadaClientFn, getKubernetesClient GetKubernetesClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"list_propagationpolicy",
+			mcp.WithDescription("List propagationpolicies under the specific namespace in the Karmada control-plane"),
+			mcp.WithString("namespace", mcp.Required(), mcp.Description("name of namespace")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKarmadaClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %v", err)
+			}
+
+			kubernetesClient, err := getKubernetesClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Kubernetes client: %v", err)
+			}
+
+			paramNamespace, ok := request.Params.Arguments["namespace"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter namespace not found")
+			}
+
+			namespace := common.NewNamespaceQuery([]string{paramNamespace})
+			dataSelect := dataselect.NoDataSelect
+			resp, err := propagationpolicy.GetPropagationPolicyList(karmadaClient, kubernetesClient, namespace, dataSelect)
+
+			if err != nil {
+				klog.Errorf("failed to list propagationpolicies, err: %v", err)
+				return nil, err
+			}
+			propagationPolicyList := make([]string, 0)
+			for _, propagationPolicy := range resp.PropagationPolicys {
+				propagationPolicyList = append(propagationPolicyList, propagationPolicy.ObjectMeta.Name)
+			}
+			r, err := json.Marshal(map[string]interface{}{
+				"propagationPolicies": propagationPolicyList,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal propagationpolicies: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}
+
+func GetPropagationPolicy(getKarmadaClient GetKarmadaClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"get_propagationpolicy",
+			mcp.WithDescription("Get propagationpolicy detailed yaml under the specific namespace in the Karmada control-plane"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("name for propagationpolicy")),
+			mcp.WithString("namespace", mcp.Required(), mcp.Description("name of namespace")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKarmadaClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %v", err)
+			}
+
+			paramName, ok := request.Params.Arguments["name"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter name not found")
+			}
+
+			paramNamespace, ok := request.Params.Arguments["namespace"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter namespace not found")
+			}
+
+			resp, err := propagationpolicy.GetPropagationPolicyDetail(karmadaClient, paramNamespace, paramName)
+			if err != nil {
+				klog.Errorf("failed to get propagationpolicy, err: %v", err)
+				return nil, err
+			}
+			r, err := json.Marshal(resp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal propagationpolicy: %w", err)
+			}
+
+			return mcp.NewToolResultText(string(r)), nil
+		}
+}
+
+func DeletePropagationPolicy(getKarmadaClient GetKarmadaClientFn) (tool mcp.Tool, handler server.ToolHandlerFunc) {
+	return mcp.NewTool(
+			"delete_propagationpolicy",
+			mcp.WithDescription("Delete propagationpolicy under the specific namespace in the Karmada control-plane"),
+			mcp.WithString("name", mcp.Required(), mcp.Description("name for propagationpolicy")),
+			mcp.WithString("namespace", mcp.Required(), mcp.Description("name of namespace")),
+		),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			karmadaClient, err := getKarmadaClient(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get Karmada client: %v", err)
+			}
+
+			paramName, ok := request.Params.Arguments["name"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter name not found")
+			}
+
+			paramNamespace, ok := request.Params.Arguments["namespace"].(string)
+			if !ok {
+				return nil, fmt.Errorf("parameter namespace not found")
+			}
+
+			err = karmadaClient.PolicyV1alpha1().PropagationPolicies(paramNamespace).Delete(ctx, paramName, metav1.DeleteOptions{})
+			if err != nil {
+				klog.ErrorS(err, "Failed to delete propagationpolicy")
+				return nil, err
+			}
+
+			return mcp.NewToolResultText("delete propagationpolicy success"), nil
+		}
+}

--- a/pkg/karmada/tools.go
+++ b/pkg/karmada/tools.go
@@ -25,8 +25,14 @@ func InitToolsetGroup(passedToolsets []string, readOnly bool, getKarmadaClient G
 		).
 		AddWriteTools()
 	policies := toolsets.NewToolset("policy", "Karmada policy related tools").
-		AddReadTools().
-		AddWriteTools()
+		AddReadTools(
+			toolsets.NewServerTool(ListPropagationPolicy(getKarmadaClient, getKubernetesClient)),
+			toolsets.NewServerTool(GetPropagationPolicy(getKarmadaClient)),
+		).
+		AddWriteTools(
+			toolsets.NewServerTool(CreatePropagationPolicy(getKarmadaClient)),
+			toolsets.NewServerTool(DeletePropagationPolicy(getKarmadaClient)),
+		)
 	resources := toolsets.NewToolset("resource", "Karmada resource related tools").
 		AddReadTools(
 			toolsets.NewServerTool(ListNamespace(getKubernetesClient)),

--- a/pkg/karmada/tools.go
+++ b/pkg/karmada/tools.go
@@ -30,9 +30,11 @@ func InitToolsetGroup(passedToolsets []string, readOnly bool, getKarmadaClient G
 	resources := toolsets.NewToolset("resource", "Karmada resource related tools").
 		AddReadTools(
 			toolsets.NewServerTool(ListNamespace(getKubernetesClient)),
+			toolsets.NewServerTool(ListDeployment(getKubernetesClient)),
 		).
 		AddWriteTools(
 			toolsets.NewServerTool(CreateNamespace(getKubernetesClient)),
+			toolsets.NewServerTool(CreateDeployment(getKubernetesClient)),
 			toolsets.NewServerTool(DeleteUnstructuredResource()),
 		)
 	// Add toolsets to the group


### PR DESCRIPTION
## Summary by Sourcery

Implement mcp server tools to manage PropagationPolicy (create, list, get, delete) and Deployment (create, list) resources, and integrate them into the policy and resource toolsets

New Features:
- Add mcp tools for creating, listing, retrieving, and deleting PropagationPolicy resources
- Add mcp tools for creating and listing Deployment resources

Enhancements:
- Register the new PropagationPolicy and Deployment tools under the appropriate policy and resource toolsets