### PR TITLE
Feat/adapt for chatui

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ MCP Server for karmada
 
 
 
-```json
+```yaml
+# for stdio mode
 {
   "mcpServers": {
     "karmada-mcp-server": {
@@ -16,6 +17,18 @@ MCP Server for karmada
         "--karmada-context=karmada-apiserver",
         "--skip-karmada-apiserver-tls-verify"
       ]
+    }
+  }
+}
+
+
+# for sse mode
+{
+  "mcpServers": {
+    "karmada-mcp-server": {
+      "name": "karmada-mcp-server",
+      "type": "sse",
+      "baseUrl": "http://localhost:1234/mcp/sse"
     }
   }
 }

--- a/cmd/karmada-mcp-server/app/sse/sse.go
+++ b/cmd/karmada-mcp-server/app/sse/sse.go
@@ -28,7 +28,7 @@ func NewSseCommand() *cobra.Command {
 			return runSseServer(sseServerConfig)
 		},
 	}
-
+	opts.AddFlags(cmd.Flags())
 	return cmd
 }
 
@@ -49,7 +49,7 @@ func runSseServer(opts SseServerOptions) error {
 	}
 
 	sseServer := server.NewSSEServer(karmadaServer,
-		server.WithBaseURL("http://localhost:5173"),
+		//server.WithBaseURL("http://localhost:5173"),
 		server.WithStaticBasePath("/mcp"),
 	)
 


### PR DESCRIPTION
## Summary by Sourcery

Support configurable SSE mode for the MCP server by adding CLI flags and updating documentation

New Features:
- Add support for SSE mode configuration

Enhancements:
- Apply CLI flags to the SSE command for customizable server options
- Remove hard-coded base URL in SSE server initialization

Documentation:
- Update README to use YAML examples and include SSE mode configuration